### PR TITLE
Add 2025-11-12 minutes #384

### DIFF
--- a/meetings/purl-community/2025-11-12.md
+++ b/meetings/purl-community/2025-11-12.md
@@ -1,0 +1,63 @@
+# Agenda for the PURL community meeting on 2025-11-12
+
+- **Host**: Remote
+- **Dates and times**:
+  - 17:00 to 18:00 UTC
+  - 19:00 to 20:00 CEST (Europe/Brussels)
+  - 12:00 to 13:00 EDT (America/New_York)
+  - 09:00 to 10:00 PDT (America/Los Angeles)
+  - 02:00 to 03:00 JST (Tokyo, Japan)
+- **Attendee information**:
+  - https://meet.google.com/ryq-aimn-ghd
+
+## Agenda items
+
+- Opening of the meeting and welcome
+- Meetings will follow the Ecma TC54 Code of Conduct https://github.com/Ecma-TC54/tg2/blob/main/CODE\_OF\_CONDUCT.md
+- PURL ECMA update - Michael
+- Package-URL website update - Michael
+- Confirm purl-spec version scheme - https://github.com/package-url/purl-spec/issues/689
+- Discuss PURL test suite - https://github.com/orgs/package-url/projects/10/views/1
+- Discuss PURL registry for packages that are not on ecosystem-managed repositories
+- Univers PRs - https://github.com/aboutcode-org/univers/pull/149, https://github.com/aboutcode-org/univers/pull/160 - Immanuel
+
+## Attendees
+
+- Philippe Ombredanne, creator of PURL, Lead maintainer of AboutCode, TC54-TG2 convener
+- Michael Herzog, AboutCode
+- Immanuel Kunz
+- Jon Moroney
+- Matt Rutkowski, IBM
+- Joshua Kugler
+- Steve Springett, ServiceNow / OWASP Foundation
+- John Horan, AboutCode
+
+## Notes
+
+- Meeting minutes are being kept and will be published, and the meeting will be recorded with Google Meet video and Gemini "note-taking".
+- Our code of conduct (link in agenda above) applies to this meeting.
+- Introductions.
+- Summary
+  - Philippe Ombredanne, Jon Moroney, Matt Rutkowski, and Joshua Kugler reviewed the agenda, and Immanuel Kunz's two PRs for the datetime ([https://github.com/aboutcode-org/univers/pull/149](https://github.com/aboutcode-org/univers/pull/149)) and lexicographic versioning schemes ([https://github.com/aboutcode-org/univers/pull/160](https://github.com/aboutcode-org/univers/pull/160)) were approved for merge following Jon Moroney''s review and Philippe Ombredanne's satisfaction with the clarifications. Philippe Ombredanne proposed and Immanuel Kunz accepted that Immanuel Kunz be given committer rights on the aboutcode-org/univers repository.
+  - Michael Herzog updated the team on the near-finalization of PURL Ecma standardization and is developing a style guide for standards documentation, which Steve Springett suggested should incorporate automation for style checks.
+  - Michael Herzog and John Horan are developing a tool grid for the website using a JSON schema, and Michael Herzog encouraged feedback on the website's structure and proposed a vote on the purl-spec version scheme, suggesting SemVer for code repos and CalVer for collections of PURL type updates.
+  - Michael Herzog is organizing the test suite to address 24 open issues and PRs, leading discussions with Philippe Ombredanne on defining "base" versus "advanced" tests, and Michael Herzog, Philippe Ombredanne, and Steve Springett agreed to organize a meeting with implementation maintainers to align on testing requirements.
+  - Philippe Ombredanne introduced a proposal for a simple Git repository-based registry for packages outside traditional registries, with Matt Rutkowski and Steve Springett supporting the idea of registering namespaces and promoting community building for the registry.
+- **Roll Call and Agenda Setting** Philippe Ombredanne initiated the meeting with a roll call and agenda check (00:00:00). Immanuel Kunz stated they had two open PRs ([https://github.com/aboutcode-org/univers/pull/149](https://github.com/aboutcode-org/univers/pull/149) and [https://github.com/aboutcode-org/univers/pull/160](https://github.com/aboutcode-org/univers/pull/160)) (00:01:15). Michael Herzog confirmed their items were already in the running notes (00:00:00).
+- **PR Review and Merge for datetime and lexicographic versioning schemes** Immanuel Kunz presented two open PRs for the datetime and lexicographic versioning schemes, with Jon Moroney having already provided a review. Philippe Ombredanne was satisfied with the clarifications, noting the importance of rigor in the context of PURL potentially moving to ISO after Ecma, which raises the bar for scrutiny (00:03:14). Philippe Ombredanne approved and moved to merge both PRs, confirming that the datetime implementation was achieved using only native libraries, despite unexpected complexities with edge cases in the ISO/RFC format that required reimplementation and testing (00:06:33).
+- **Future Work and Committer Rights for Immanuel Kunz** Immanuel Kunz noted that the only remaining open item for them is adding libversion as a fallback. Philippe Ombredanne suggested that Immanuel Kunz be given commit rights on the aboutcode-org/univers repository to make their work more convenient and visible, which Immanuel Kunz accepted (00:07:58).
+- **PURL Ecma Standardization Update** Michael Herzog provided an update on the PURL Ecma standardization, with all changes being editorial, such as replacing "must" with "shall" to meet ISO requirements (00:09:28). Steve Springett found the difference in meaning between "must" in ISO and RFC contexts interesting, as "must" in ISO means a mandate from an external authority and not necessarily a requirement for the standard itself (00:11:47).
+- **Style Guide and Automation for Standards** Michael Herzog is working on a draft style guide for documentation and standards, based on lessons learned from the Ecma review cycle (00:10:42). Steve Springett suggested that automation for catching style issues, like a spell check for Oxford dialect and blocking words like "must," would be beneficial to prevent last-minute issues. Michael Herzog agreed on the need for automation but is currently focused on documenting the encountered problems and solutions (00:12:51).
+- **Website Updates and Tool Grid Development** Michael Herzog provided an update on the website, noting that the content has been streamlined, removing the "participate" and "getting started" pages. The tool grid is being developed, modeling the CycloneDX Tool Center ([https://cyclonedx.org/tool-center/](https://cyclonedx.org/tool-center/)), with John Horan and Michael Herzog working on prototype attributes, aiming to use a JSON schema for data storage due to the complexity of multiple attributes and values (00:13:53). They also noted that most current entries are from open-source projects, and they need to consider attributes for commercial use (00:16:11).
+- **Feedback on Website Issues and Filtering Implementation** Michael Herzog encouraged feedback on various aspects of the website, including the homepage, purl-spec, vers-spec, and header/footer, through open issues on the package.org repo (00:17:24). Steve Springett offered help with the filtering for the tool grid, which is currently implemented in the CycloneDX Tool Center by overloading HTML data attributes since they are avoiding a relational database (00:18:20). This approach, however, may negatively affect mobile performance (00:19:31).
+- **purl-spec Version Scheme Proposal and Tagging** Michael Herzog requested feedback on the proposed purl-spec version scheme, which suggests using SemVer for code repos and CalVer for collections of PURL type updates. They plan to propose a vote on this in the TG2 meeting no later than the following week, as this is a gating item for tagging version 1.0 for purl-spec, now that the Ecma standard is finalized (00:20:21).
+- **Test Suite Organization and Documentation Review** Michael Herzog started a new GitHub project to organize and address the schema and documentation issues within the test suite, which currently has 24 open issues and PRs ([https://github.com/orgs/package-url/projects/10](https://github.com/orgs/package-url/projects/10)) (00:21:25). A revised \`test.md\` file is being drafted to propose updated terminology and structure, addressing topics like validation tests, the definition of "advanced" versus "base" tests, and the use case for "roundtrip" tests (00:22:37). Michael Herzog confirmed that Jan Kowalleck's idea of a component-level test file, such as one for qualifiers ([https://github.com/package-url/purl-spec/pull/738](https://github.com/package-url/purl-spec/pull/738)), is a good idea (00:23:40).
+- **Defining Base and Advanced Tests** Michael Herzog and Philippe Ombredanne discussed the need for clearer definitions of test types, concluding that "base" tests are likely strict pass/fail tests, potentially encompassing all specification tests, while "advanced" tests would be reserved for PURL types (00:24:42). Michael Herzog stressed that better organization of the test suite is a major blocker for clearing the backlog and ensuring that new PURL type submissions know what is expected of them (00:25:54).
+- **Challenges with Test Suite Adoption by Implementations** Steve Springett inquired about the status of PURL implementations adopting the 1.0 standard. Michael Herzog explained that some maintainers, such as those for the PHP implementation, are holding off on updates until the testing requirements are clearly defined and stabilized (00:27:04). Philippe Ombredanne and Steve Springett agreed that organizing a meeting with all official implementation maintainers would be beneficial to align on the testing plan (00:29:08).
+- **Technical Issues with Test Suite Integration** Philippe Ombredanne noted that the current approach for integrating the test suite via Git modules, while used for Python, faces issues, such as how to mark a failing test as acceptable temporarily (00:30:21). Michael Herzog proposed extending the CalVer versioning to the tests, creating periodic updates with fixed targets to make vendoring easier (00:32:25).
+- **Documentation and Site Search Functionality** Matt Rutkowski suggested implementing the built-in search functionality of Docusaurus for the website, which indexes markdown pages and provides a search bar, as it is a fantastic feature used widely (00:34:19). Michael Herzog confirmed plans to reset the documentation files under "standards" to align with the latest Ecma documents, treating this as an editorial, non-normative cleanup item (00:36:12).
+- **Registry Proposal for Packages Outside Traditional Registries** Philippe Ombredanne introduced the idea of creating a simple Git repository-based registry for packages not in traditional registries (like Linux repos or C++ dependencies), citing the need for minting PURLs for these types of components as requested by maintainers (00:37:05). The proposal suggests registering namespaces and names, with the community ensuring no conflicts, similar to the process for CycloneDX properties (00:39:47).
+- **Outreach and Namespace Considerations for the Registry** Matt Rutkowski suggested compiling a list of communities for outreach, such as Kaggle, to encourage their adoption of PURL (00:41:20). Steve Springett expressed support for ad hoc registration of namespaces but cautioned against confusing a PURL type with a namespace, suggesting using a specific type like "pkg:purl-microsoft" for registered items (00:42:07). Matt Rutkowski elaborated on the need for internal identifiers for proprietary software to clearly identify IBM-specific components when sharing SBOMs (00:43:28) (00:46:19).
+- **Historical vs. Forward-Looking Registry and Community Building** Jon Moroney questioned whether the goal of the registry is to be forward-looking (for new registrations) or historical, noting the potential for namespace conflicts if trying to do both (00:46:19). Steve Springett emphasized the value of registering products outside of package registries, allowing proprietary companies to engage with the software industry and enabling automated resolution for those using formats like SWID (00:47:21). Jon and Matt Rutkowski agreed that building the community is key to the registry's success and endorsed the continuation of using external references for proprietary component identification (00:49:19).
+- **Increased Collaboration and PURL Adoption Successes** Philippe Ombredanne proposed adding Jon Moroney as a contributor to the purl-spec Git repo due to their diligent participation (00:50:09). Steve Springett noted significant progress in PURL adoption, including the new Maven Central publishing process which supports PURL natively and even prioritizes the PURL over the Group Artifact Version (GAV) (00:52:13). Jon pointed out a potential bug in Maven Central's copy button where the PURL initially loads as a generic placeholder (00:54:09).
+- The meeting was adjourned.


### PR DESCRIPTION
Added the 2025-11-12 PURL community meeting minutes as.md.

Reference: https://github.com/package-url/purl-spec/issues/384